### PR TITLE
Enable Lucene Full Text Search by default NethServer/dev#5106

### DIFF
--- a/root/etc/e-smith/db/configuration/defaults/dovecot/FtsLuceneStatus
+++ b/root/etc/e-smith/db/configuration/defaults/dovecot/FtsLuceneStatus
@@ -1,0 +1,1 @@
+enabled

--- a/root/etc/e-smith/templates/etc/dovecot/dovecot.conf/40namespaces
+++ b/root/etc/e-smith/templates/etc/dovecot/dovecot.conf/40namespaces
@@ -54,7 +54,12 @@ namespace PUBLIC \{
 
 # Enable acl plugin for shared mailboxes, 
 # and listescape to extend allowable characters in mailbox names
-mail_plugins = $mail_plugins acl listescape
+mail_plugins = $mail_plugins acl listescape {
+    $OUT = '';
+    if(($dovecot{'FtsLuceneStatus'} || '') eq 'enabled') {
+        $OUT = 'fts fts_lucene';
+    }
+}
 protocol imap \{
   mail_plugins = $mail_plugins imap_acl
 \}
@@ -62,6 +67,12 @@ protocol imap \{
 plugin \{
   acl = vfile
   acl_shared_dict = file:/var/lib/nethserver/vmail/shared-mailboxes.db
+  {
+    $OUT = '';
+    if(($dovecot{'FtsLuceneStatus'} || '') eq 'enabled') {
+        $OUT = "fts = lucene\n  fts_lucene = whitespace_chars=@.";
+    }
+  }
 \}
 
 service dict \{


### PR DESCRIPTION
The Lucene plugin is available from upstream dovecot package.

This PR defines a new prop for the ``dovecot`` key: ``FtsLuceneStatus``, set to ``enabled`` by default.

NethServer/dev#5106