### PR TITLE
Configure postlogin script for managesieve NethServer/dev#5150

### DIFF
--- a/root/etc/e-smith/templates/etc/dovecot/dovecot.conf/40namespaces
+++ b/root/etc/e-smith/templates/etc/dovecot/dovecot.conf/40namespaces
@@ -82,17 +82,6 @@ service dict \{
   \}
 \}
 
-service imap \{
-  executable = imap imap-postlogin
-\}
-
-service imap-postlogin \{
-  executable = script-login /usr/libexec/nethserver/dovecot-postlogin
-  user = $default_internal_user
-  unix_listener imap-postlogin \{
-  \}
-\}
-
 service imap-login \{
    unix_listener imap-ipc \{
      group = root

--- a/root/etc/e-smith/templates/etc/dovecot/dovecot.conf/40postlogin
+++ b/root/etc/e-smith/templates/etc/dovecot/dovecot.conf/40postlogin
@@ -1,0 +1,28 @@
+#
+# 40postlogin (imap, managesieve)
+#
+
+service imap \{
+  executable = imap imap-postlogin
+\}
+
+service imap-postlogin \{
+  executable = script-login /usr/libexec/nethserver/dovecot-postlogin
+  user = $default_internal_user
+  unix_listener imap-postlogin \{
+  \}
+\}
+
+service managesieve \{
+  executable = managesieve sieve-postlogin
+\}
+
+service sieve-postlogin \{
+  executable = script-login /usr/libexec/nethserver/dovecot-postlogin
+  user = $default_internal_user
+  unix_listener sieve-postlogin \{
+  \}
+\}
+
+
+

--- a/root/usr/libexec/nethserver/dovecot-postlogin
+++ b/root/usr/libexec/nethserver/dovecot-postlogin
@@ -23,15 +23,14 @@
 use strict;
 use Sys::Hostname;
 
-my ($system_name, $domain_name) = split(/\./, hostname(), 2);
-
 my $user = $ENV{USER};
-if($user !~ /\@/) {
+if($user !~ /\@/ && $user ne 'root' && $user ne 'vmail') {
+    my ($system_name, $domain_name) = split(/\./, hostname(), 2);
     $user = $user . '@' . $domain_name;
     $ENV{HOME} = '/var/lib/nethserver/vmail/' . $user;
-    $ENV{USERDB_KEYS} .= 'home ';
+    $ENV{USER} = $user;
+    $ENV{USERDB_KEYS} .= 'user home ';
 }
-$ENV{USER} = $user;
 
 # Read secondary groups and prepare a CSV list
 my @groups = map { sprintf('%s', (getgrgid($_))[0]) } split(/ /, qx(id -G \$USER));
@@ -41,7 +40,7 @@ $ENV{MASTER_USER}=$ENV{USER};
 #
 # Export USERDB overrides
 #
-$ENV{USERDB_KEYS} .= 'user acl_groups master_user ';
+$ENV{USERDB_KEYS} .= 'acl_groups master_user ';
 
 #
 # Export quota


### PR DESCRIPTION
The user name and homedir path is mangled by the imap-postlogin script which adds the ``@domain`` suffix if missing. This PR executes the same postlogin script in the managesieve server, so that they both write to the same home directory.

Moreover, an exception to the rule above is made for ``root`` and ``vmail`` builtin users.

NethServer/dev#5150