### PR TITLE
Enable user shared mailbox - NethServer/dev#5192

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -187,16 +187,14 @@ To avoid typing the password again and again write it in ``.muttrc``: ::
 
 ``PASSWORD`` must be URL-encoded. For instance the slash character ``/`` is encoded as ``%2f``.
 
-Active Directory configuration
-------------------------------
+Set special ACL
+---------------
 
-To configure mutt for GSSAPI authentication ::
+You can use ``doveadm`` to set special ACL on shared folder: ::
 
-    yum install krb5-workstation
-    cat - <<EOF > ~/.muttrc
-    set spoolfile="imaps://vm5.dpnet.nethesis.it/"
-    set folder=""
-    set imap_user=davide.principi@DPNET.NETHESIS.IT
-    set imap_authenticators="gssapi"
-    EOF
-    mutt
+  doveadm acl set -u <user> <shared_folder> <subject> <flags>
+
+Example: allow insert and expunge to user goofy on public folder testshare (domain of the machine is local.nethserver.org): ::
+
+  doveadm acl set -u goofy@local.nethserver.org Public/testshare "user=goofy@local.nethserver.org" insert expunge
+

--- a/root/etc/e-smith/db/configuration/defaults/dovecot/SharedMailboxesStatus
+++ b/root/etc/e-smith/db/configuration/defaults/dovecot/SharedMailboxesStatus
@@ -1,1 +1,1 @@
-disabled
+enabled

--- a/root/etc/e-smith/templates/etc/dovecot/dovecot.conf/40namespaces
+++ b/root/etc/e-smith/templates/etc/dovecot/dovecot.conf/40namespaces
@@ -36,7 +36,7 @@ namespace SHARED_USERS \{
   type = shared
   disabled = { $dovecot{SharedMailboxesStatus} eq 'enabled' ? 'no' : 'yes' }
   separator = /
-  prefix = Shared/%%u/
+  prefix = Shared/%%n@{{ $DomainName }}/
   location = maildir:/var/lib/nethserver/vmail/%%u/Maildir:INDEXPVT=~/Maildir/shared/%%u
   subscriptions = no
   list = children

--- a/root/usr/share/nethesis/NethServer/Language/en/NethServer_Module_MailAccount_SharedMailbox.php
+++ b/root/usr/share/nethesis/NethServer/Language/en/NethServer_Module_MailAccount_SharedMailbox.php
@@ -13,3 +13,4 @@ $L['ExtraFields_label'] = 'Additional actions';
 $L['ANY_DOMAIN'] = '[all domains]';
 $L['localAddress_label'] = 'Local address';
 $L['valid_email,malformed-localpart'] = 'Invalid email alias';
+$L['no_special_access_label'] = 'No extra ACL set';

--- a/root/usr/share/nethesis/NethServer/Module/MailAccount/SharedMailbox/Edit.php
+++ b/root/usr/share/nethesis/NethServer/Module/MailAccount/SharedMailbox/Edit.php
@@ -188,7 +188,7 @@ class Edit extends \Nethgui\Controller\Table\AbstractAction
             $view->setTemplate('Nethgui\Template\Table\Delete');
         } elseif ($this->getIdentifier() === 'update') {
             $view['OwnersDatasource'] = $this->getOwnersDatasource($view);
-            $view['Others'] = $this->others;
+            $view['Others'] = $this->others ? $this->others : $view->translate("no_special_access_label");
             $view->setTemplate('NethServer\Template\MailAccount\SharedMailbox\Edit');
         }
         if ($this->getRequest()->isMutation()) {

--- a/root/usr/share/nethesis/NethServer/Template/MailAccount/SharedMailbox/Edit.php
+++ b/root/usr/share/nethesis/NethServer/Template/MailAccount/SharedMailbox/Edit.php
@@ -4,6 +4,8 @@
 if ($view->getModule()->getIdentifier() === 'create') {
     $headerText = $T('SharedMailbox_create_header');
 } else {
+    $special_access = $view->fieldset()->setAttribute('template', $T('Others_label'))
+        ->insert($view->textList('Others'));
     $headerText = $T('SharedMailbox_modify_header');
 }
 
@@ -24,8 +26,8 @@ echo	$view->fieldset()->setAttribute('template', $T('ExtraFields_label'))
     ;
 }
 
-echo $view->fieldset()->setAttribute('template', $T('Others_label'))
-        ->insert($view->textList('Others'));
-;
+if ($view->getModule()->getIdentifier() === 'update') {
+    echo $special_access;
+}
 
 echo $view->buttonList($view::BUTTON_SUBMIT | $view::BUTTON_CANCEL | $view::BUTTON_HELP);


### PR DESCRIPTION
- SharedMailboxesStatus default to `enabled`
- Web interface: hide 'Special access' field on creation
- Hide vmail mailbox under SHARED_USERS namespace
- Document `doveadm acl` command

NethServer/dev#5192