### PR TITLE
Fix group members expansion

### DIFF
--- a/root/usr/share/nethesis/NethServer/Module/MailAccount/Pseudonym/Modify.php
+++ b/root/usr/share/nethesis/NethServer/Module/MailAccount/Pseudonym/Modify.php
@@ -98,7 +98,7 @@ class Modify extends \Nethgui\Controller\Table\Modify
             $destinations = array();
             foreach($this->parameters['Account'] as $destination) {
                 if(in_array($destination, array_keys($groupList))) {
-                    $destinations = array_merge($destinations, $groupList[$destination]['members']);
+                    $destinations = array_merge($destinations, $groupProvider->getGroupMembers($destination));
                 } else {
                     $destinations[] = $destination;
                 }


### PR DESCRIPTION
The helper script does not return group members any more. An explicit
call to getGroupMembers() is required.

NethServer/dev#5207