### PR TITLE
spam-expunge: avoid cron output for vmail public mailbox

### DIFF
--- a/root/etc/cron.daily/nethserver-mail-spam-expunge
+++ b/root/etc/cron.daily/nethserver-mail-spam-expunge
@@ -32,7 +32,6 @@ for MDIR in /var/lib/nethserver/vmail/*/Maildir; do
 
     if [[ "${USER}" == vmail ]]; then
         if [[ -n "${SpamFolder}" && -d "$MDIR/.${SpamFolder}" ]]; then
-            echo "[WARNING] Removing ${SpamFolder} from vmail public mailbox"
             rm -rf "$MDIR/.${SpamFolder}"
         fi
         continue


### PR DESCRIPTION
Every night I receive an annoying mail with the following output:
```
/etc/cron.daily/nethserver-mail-spam-expunge:

[WARNING] Removing junkmail from vmail public mailbox
```