### PR TITLE
Restrict catch all to local mailboxes

### DIFF
--- a/root/usr/share/nethesis/NethServer/Language/en/NethServer_Module_Mail_Domain_PlugTransport_LocalDelivery.php
+++ b/root/usr/share/nethesis/NethServer/Language/en/NethServer_Module_Mail_Domain_PlugTransport_LocalDelivery.php
@@ -9,3 +9,4 @@ $L['UnknownRecipientsActionDeliverMailbox_label'] = 'Deliver to';
 $L['UnknownRecipientsActionType_label'] = 'Accept unknown recipients';
 $L['Users_label'] = 'Users';
 $L['valid_catchall_mailbox_primary'] = 'A local mailbox identifier, like "root", or "username@${0}"';
+$L['SharedMailbox_selector_label'] = '${0} (shared mailbox)';

--- a/root/usr/share/nethesis/NethServer/Module/Mail/Domain/PlugTransport/LocalDelivery.php
+++ b/root/usr/share/nethesis/NethServer/Module/Mail/Domain/PlugTransport/LocalDelivery.php
@@ -56,7 +56,7 @@ class LocalDelivery extends \Nethgui\Controller\Table\RowPluginAction
                 if( ! preg_match("/^[^@]+(@${domainName})?$/", $this->parameters['UnknownRecipientsActionDeliverMailbox']) ) {
                     $report->addValidationErrorMessage($this, 'UnknownRecipientsActionDeliverMailbox', 'valid_catchall_mailbox_primary', array($domainName));
                 }
-            } else {
+            } elseif( $this->parameters['UnknownRecipientsActionDeliverMailbox'] !== 'root' && substr($this->parameters['UnknownRecipientsActionDeliverMailbox'], 0, 6) !== 'vmail+' ) {
                 $v = $this->createValidator()->email();
                 if( ! $v->evaluate($this->parameters['UnknownRecipientsActionDeliverMailbox'])) {
                     $report->addValidationError($this, 'UnknownRecipientsActionDeliverMailbox', $v);

--- a/root/usr/share/nethesis/NethServer/Module/Mail/Domain/PlugTransport/LocalDelivery.php
+++ b/root/usr/share/nethesis/NethServer/Module/Mail/Domain/PlugTransport/LocalDelivery.php
@@ -65,4 +65,42 @@ class LocalDelivery extends \Nethgui\Controller\Table\RowPluginAction
         }
         parent::validate($report);
     }
+
+    public function prepareView(\Nethgui\View\ViewInterface $view)
+    {
+        parent::prepareView($view);
+        $mailboxesDatasource = array();
+        foreach($this->getLocalMailboxes() as $mbx) {
+            if(substr($mbx, 0, 6) === 'vmail+') {
+                $mailboxesDatasource[] = array($mbx, $view->translate('SharedMailbox_selector_label', array(substr($mbx, 6))));
+            } else {
+                $mailboxesDatasource[] = array($mbx, $mbx);
+            }
+        }
+        $view['UnknownRecipientsActionDeliverMailboxDatasource'] = $mailboxesDatasource;
+    }
+
+    private function getLocalMailboxes()
+    {
+        $userProvider = new \NethServer\Tool\UserProvider($this->getPlatform());
+        $mbxProvider = new \NethServer\Module\MailAccount\SharedMailbox\SharedMailboxAdapter($this->getPlatform());
+        $mailboxes = array('root');
+
+        $users = $userProvider->getUsers();
+        ksort($users);
+
+        foreach ($users as $key => $prop) {
+            $mailboxes[] = $key;
+        }
+
+        foreach ($mbxProvider->getSharedMailboxList() as $mbx) {
+            $mailboxes[] = 'vmail+' . $mbx['name'];
+        }
+
+        if(isset($this->parameters['UnknownRecipientsActionDeliverMailbox']) && $this->parameters['UnknownRecipientsActionDeliverMailbox'] && ! in_array($this->parameters['UnknownRecipientsActionDeliverMailbox'], $mailboxes))  {
+            array_unshift($mailboxes, $this->parameters['UnknownRecipientsActionDeliverMailbox']);
+        }
+
+        return $mailboxes;
+    }
 }

--- a/root/usr/share/nethesis/NethServer/Template/Mail/Domain/PlugTransport/LocalDelivery.php
+++ b/root/usr/share/nethesis/NethServer/Template/Mail/Domain/PlugTransport/LocalDelivery.php
@@ -7,7 +7,5 @@ echo $view->fieldsetSwitch('AlwaysBccStatus', 'enabled', $view::FIELDSETSWITCH_C
 
 echo $view->fieldsetSwitch('UnknownRecipientsActionType', 'deliver', $view::FIELDSETSWITCH_CHECKBOX | $view::FIELDSETSWITCH_EXPANDABLE)
     ->setAttribute('uncheckedValue', 'bounce')
-    ->insert($view->textInput('UnknownRecipientsActionDeliverMailbox'))
+    ->insert($view->selector('UnknownRecipientsActionDeliverMailbox', $view::SELECTOR_DROPDOWN))
 ;
-
-


### PR DESCRIPTION
Undeliverable messages are sent to a local mailbox only. Existing values
are retained - remote addresses are still valid for alias domains. New
domain records can select only local mailboxes.

NethServer/dev#5379