### PR TITLE
Add shared mailboxes definition to config backup

### DIFF
--- a/createlinks
+++ b/createlinks
@@ -225,6 +225,12 @@ event_actions('post-restore-data', qw(
 #
 event_actions('post-restore-config', qw(
     nethserver-mail-upgrade-ns6db 60
+    nethserver-mail-shrmbx-cfgrestore 60
 ));
 
-
+#
+# pre-backup-config event
+#
+event_actions('pre-backup-config', qw(
+    nethserver-mail-shrmbx-cfgbackup 40
+));

--- a/root/etc/backup-config.d/nethserver-mail-server.include
+++ b/root/etc/backup-config.d/nethserver-mail-server.include
@@ -1,0 +1,1 @@
+/var/lib/nethserver/backup/nethserver-mail-shrmbx.tar

--- a/root/etc/e-smith/events/actions/nethserver-mail-shrmbx-cfgbackup
+++ b/root/etc/e-smith/events/actions/nethserver-mail-shrmbx-cfgbackup
@@ -1,0 +1,28 @@
+#!/bin/bash
+#
+# Copyright (C) 2017 Nethesis S.r.l.
+# http://www.nethesis.it - nethserver@nethesis.it
+#
+# This script is part of NethServer.
+#
+# NethServer is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License,
+# or any later version.
+#
+# NethServer is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with NethServer.  If not, see COPYING.
+#
+
+arc=/var/lib/nethserver/backup/nethserver-mail-shrmbx.tar
+
+rm -f $arc
+
+cd /var/lib/nethserver/vmail/vmail
+
+find . -type f -name dovecot-acl | tar -c -T - -f $arc

--- a/root/etc/e-smith/events/actions/nethserver-mail-shrmbx-cfgrestore
+++ b/root/etc/e-smith/events/actions/nethserver-mail-shrmbx-cfgrestore
@@ -1,0 +1,29 @@
+#!/bin/bash
+#
+# Copyright (C) 2017 Nethesis S.r.l.
+# http://www.nethesis.it - nethserver@nethesis.it
+#
+# This script is part of NethServer.
+#
+# NethServer is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License,
+# or any later version.
+#
+# NethServer is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with NethServer.  If not, see COPYING.
+#
+
+arc=/var/lib/nethserver/backup/nethserver-mail-shrmbx.tar
+
+if [[ ! -f $arc ]]; then
+    echo "[NOTICE] shared mailboxes are missing from config backup: old archive format?"
+    exit 0
+fi
+
+tar -C /var/lib/nethserver/vmail/vmail -x -f $arc


### PR DESCRIPTION
Store the mailboxes definition in a separate .tar file, to restore
filesystem permissions after vmail user has been created.

NethServer/dev#5381