### PR TITLE
Add ipaccess.conf config file

### DIFF
--- a/createlinks
+++ b/createlinks
@@ -45,6 +45,7 @@ my @saveTemplates = qw(
     /etc/dovecot/quota.passwd
     /etc/pam.d/dovecot-master
     /var/lib/nethserver/sieve-scripts/before.sieve
+    /etc/dovecot/ipaccess.conf
 );
 
 # UPDATE templates

--- a/createlinks
+++ b/createlinks
@@ -235,3 +235,10 @@ event_actions('post-restore-config', qw(
 event_actions('pre-backup-config', qw(
     nethserver-mail-shrmbx-cfgbackup 40
 ));
+
+#
+# trusted-networks-modify event
+#
+event_templates('trusted-networks-modify', qw(
+    /etc/dovecot/ipaccess.conf
+));

--- a/nethserver-mail-server.spec
+++ b/nethserver-mail-server.spec
@@ -62,6 +62,7 @@ usermod -G vmail -a postfix >/dev/null 2>&1
 %dir %attr(0775,root,root) %{_sysconfdir}/dovecot/sievc/Maildir
 %config %attr (0440,root,root) %{_sysconfdir}/sudoers.d/20_nethserver_mail_server
 %attr(0644,root,root) %config %ghost %{_sysconfdir}/systemd/system/dovecot.service.d/limits.conf
+%attr(0644,root,root) %config %ghost %{_sysconfdir}/dovecot/ipaccess.conf
 
 %changelog
 * Fri Nov 24 2017 Giacomo Sanchietti <giacomo.sanchietti@nethesis.it> - 1.10.18-1
@@ -285,4 +286,3 @@ usermod -G vmail -a postfix >/dev/null 2>&1
 - Migrate admin's standard mailbox to vmail storage. Refs #1622
 - Grant IMAP access to system users in /etc/dovecot/system-users passwd database. Refs #1622
 - Dovecot certificates under nethserver-base certificate management. Refs #1634
-

--- a/root/etc/e-smith/templates/etc/dovecot/ipaccess.conf/20restricted_access_group
+++ b/root/etc/e-smith/templates/etc/dovecot/ipaccess.conf/20restricted_access_group
@@ -1,0 +1,10 @@
+#
+# 20restricted_access_group
+#
+{
+    use NethServer::TrustedNetworks;
+    $OUT = '';
+    if($dovecot{'RestrictedAccessGroup'}) {
+        $OUT = $dovecot{'RestrictedAccessGroup'} . ' = ' . join(', ', '127.0.0.1', NethServer::TrustedNetworks::list_cidr()) . "\n";
+    }
+}

--- a/root/usr/libexec/nethserver/dovecot-postlogin
+++ b/root/usr/libexec/nethserver/dovecot-postlogin
@@ -22,6 +22,7 @@
 
 use strict;
 use Sys::Hostname;
+use NetAddr::IP qw(:lower);
 
 my $user = $ENV{USER};
 if($user !~ /\@/ && $user ne 'root' && $user ne 'vmail') {
@@ -43,7 +44,35 @@ $ENV{MASTER_USER}=$ENV{USER};
 $ENV{USERDB_KEYS} .= 'acl_groups master_user ';
 
 #
+# ipaccess.conf -- restrict access by IP policy (#5395)
+#
+if($ENV{IP} && -r '/etc/dovecot/ipaccess.conf') {
+    my $allow_access = 1; # Default is temporary ALLOW
+    my $client_ip = NetAddr::IP->new($ENV{IP});
+    open(my $iph, '<', '/etc/dovecot/ipaccess.conf');
+    while(<$iph>) {
+        chomp;
+        m/^(?:\s+)?(.+?)(?:\s*=\s*)(.+?)(?:\s*)?$/;
+        if($1 =~ m/^#/) {
+            next; # Skip comment lines
+        } elsif(grep { $_ eq $1 } @groups) {
+            $allow_access = 0; # Matching a restricted group line implies temporary DENY
+            if(grep { $_ && $client_ip->within(NetAddr::IP->new($_)) } split(/,\s*/, $2)) {
+                $allow_access = 1; # The first matching subnet implies a final ALLOW decision
+                last;
+            }
+        }
+    }
+    close($iph);
+    if(!$allow_access) {
+        print "* NO [ALERT] Access not allowed from your IP\r\n";
+        exit(0);
+    }
+}
+
+
+
+#
 # The ENVironment is ready, we are done.
 #
 exec(@ARGV) or die "Unable to exec @ARGV: $!";
-


### PR DESCRIPTION
Evaluate access permissions in dovecot-postlogin script by searching a
matching IP in the config file, indexed by long group names.

The default policy is ALLOW. A matching group name implies DENY, if the
client IP does not match any listed subnet.

The config file is actually generated by a template, controlled by dovecot `RestrictedAccessGroup` prop. Members of the given `RestrictedAccessGroup` have IMAP access limited to trusted networks.

Sample usage:

```text
config setprop dovecot RestrictedAccessGroup g1@dpnet.nethesis.it
signal-event nethserver-mail-server-save
```

NethServer/dev#5395
